### PR TITLE
[win32] Remove obsolete patching code from bld.bat

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,16 +1,3 @@
-REM TODO(galexite): remove once llvm/llvm-project#83807 has been merged
-echo from pathlib import Path                                                    >> _windows_patch.py
-echo import re                                                                   >> _windows_patch.py
-echo cmakelists = Path.cwd() / 'CMakeLists.txt'                                  >> _windows_patch.py
-echo contents = cmakelists.read_text(encoding='utf-8')                           >> _windows_patch.py
-echo contents = re.sub(                                                          >> _windows_patch.py
-echo   r'project\(([^^\n]+)\)',                                                  >> _windows_patch.py
-echo   r'project(\1 LANGUAGES CXX)\ninclude(GNUInstallDirs)', contents, count=1) >> _windows_patch.py
-echo cmakelists.write_text(contents, encoding='utf-8')                           >> _windows_patch.py
-python _windows_patch.py
-if %ERRORLEVEL% neq 0 exit 1
-del _windows_patch.py
-
 mkdir build
 cd build
 


### PR DESCRIPTION
Removed temporary patching script which should no longer be necessary.